### PR TITLE
Option to avoid resending translated texts for translation

### DIFF
--- a/src/Commands/TranslateCommand.php
+++ b/src/Commands/TranslateCommand.php
@@ -23,8 +23,16 @@ class TranslateCommand extends Command
         $overwrite = $this->option('overwrite');
 
         try {
-            $manager->translate($sourceLang, $targetLang, $driver, $overwrite);
-            $this->info("Translation to '{$targetLang}' using '{$driver}' driver completed and saved.");
+            [$translationCount, $warnings] = $manager->translate($sourceLang, $targetLang, $driver, $overwrite);
+            if ($translationCount <= 0) {
+                $this->info('No translations needed.');
+            } else {
+                $this->info("Translation to '{$targetLang}' using '{$driver}' driver completed and saved.");
+                $this->info("{$translationCount} strings translated.");
+            }
+            foreach ($warnings as $warning) {
+                $this->warn($warning);
+            }
         } catch (Exception $e) {
             $this->error('An error occurred during translation: ' . $e->getMessage());
         }

--- a/src/TranslationWorkflowService.php
+++ b/src/TranslationWorkflowService.php
@@ -45,6 +45,9 @@ class TranslationWorkflowService
     public function translate(string $sourceLang, string $targetLang, string $driver, bool $overwrite = false): array
     {
         $texts = $this->loadTexts();
+        if (! $overwrite) {
+            $texts = $this->compareTranslations($texts, $targetLang);
+        }
         $translated = $this->service->translate($texts, $sourceLang, $targetLang, $driver);
 
         if (isset($this->inMemoryTexts)) {
@@ -153,5 +156,29 @@ class TranslationWorkflowService
         }
 
         File::put($file, json_encode($translated, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * Compare previously translated file and remove from texts to be translated.
+     *
+     * @param  array  $texts  The array of texts to be translated.
+     * @param  string  $lang  The target language code.
+     *
+     * @return array The array of texts to be translated.
+     */
+    private function compareTranslations(array $texts, string $lang): array
+    {
+        $file = config('auto-translations.lang_path')."/{$lang}.json";
+
+        if (!File::exists($file)) {
+            return $texts;
+        }
+
+        $existing = json_decode(File::get($file), true) ?: [];
+        foreach (array_keys($existing) as $key) {
+            unset($texts[$key]);
+        }
+
+        return $texts;
     }
 }

--- a/src/TranslationWorkflowService.php
+++ b/src/TranslationWorkflowService.php
@@ -48,7 +48,11 @@ class TranslationWorkflowService
         if (! $overwrite) {
             $texts = $this->compareTranslations($texts, $targetLang);
         }
-        $translated = $this->service->translate($texts, $sourceLang, $targetLang, $driver);
+        if (empty($texts)) {
+            return [0,[]];
+        }
+
+        [$translated, $warnings] = $this->service->translate($texts, $sourceLang, $targetLang, $driver);
 
         if (isset($this->inMemoryTexts)) {
             return $translated;
@@ -56,7 +60,7 @@ class TranslationWorkflowService
 
         $this->saveTranslated($translated, $targetLang, $overwrite);
 
-        return $translated;
+        return [count($translated), $warnings];
     }
 
     /**


### PR DESCRIPTION
Do not send previously translated texts for translation again unless overwrite is requested.
Resolves #9