### PR TITLE
Avoid resending translated texts for translation

### DIFF
--- a/src/Commands/TranslateCommand.php
+++ b/src/Commands/TranslateCommand.php
@@ -23,8 +23,16 @@ class TranslateCommand extends Command
         $overwrite = $this->option('overwrite');
 
         try {
-            $manager->translate($sourceLang, $targetLang, $driver, $overwrite);
-            $this->info("Translation to '{$targetLang}' using '{$driver}' driver completed and saved.");
+            [$translationCount, $warnings] = $manager->translate($sourceLang, $targetLang, $driver, $overwrite);
+            if ($translationCount <= 0) {
+                $this->info('No translations needed.');
+            } else {
+                $this->info("Translation to '{$targetLang}' using '{$driver}' driver completed and saved.");
+                $this->info("{$translationCount} strings translated.");
+            }
+            foreach ($warnings as $warning) {
+                $this->warn($warning);
+            }
         } catch (Exception $e) {
             $this->error('An error occurred during translation: ' . $e->getMessage());
         }

--- a/src/TranslationWorkflowService.php
+++ b/src/TranslationWorkflowService.php
@@ -48,7 +48,11 @@ class TranslationWorkflowService
         if (! $overwrite) {
             $texts = $this->compareTranslations($texts, $targetLang);
         }
-        $translated = $this->service->translate($texts, $sourceLang, $targetLang, $driver);
+        if (empty($texts)) {
+            return [0,[]];
+        }
+
+        [$translated, $warnings] = $this->service->translate($texts, $sourceLang, $targetLang, $driver);
 
         if (isset($this->inMemoryTexts)) {
             return $translated;
@@ -56,7 +60,7 @@ class TranslationWorkflowService
 
         $this->saveTranslated($translated, $targetLang, $overwrite);
 
-        return $translated;
+        return [count($translated), $warnings];
     }
 
     /**


### PR DESCRIPTION
This PR adds the following functionality:

- Option to avoid resending previously translated strings for translation (overwrite argument will send all)
- Improved placeholder mapping for faster referencing with hashed array
- Feedback for number of strings translated (to account for no translations needed)
- Warnings if any possible placeholders remain in output files.