### PR TITLE
Fix GoogleTranslateDriver

### DIFF
--- a/src/Drivers/GoogleTranslateDriver.php
+++ b/src/Drivers/GoogleTranslateDriver.php
@@ -24,10 +24,11 @@ class GoogleTranslateDriver implements TranslationDriver
             'source' => $sourceLang,
             'target' => $targetLang,
             'format' => 'text',
+            'key' => $apiKey,
         ];
 
         $response = Http::asJson()->post(
-            'https://translation.googleapis.com/language/translate/v2?key=' . urlencode($apiKey),
+            'https://translation.googleapis.com/language/translate/v2',
             $body
         );
 

--- a/src/Drivers/GoogleTranslateDriver.php
+++ b/src/Drivers/GoogleTranslateDriver.php
@@ -18,26 +18,32 @@ class GoogleTranslateDriver implements TranslationDriver
     public function translate(array $texts, string $sourceLang, string $targetLang): array
     {
         $apiKey = $this->config['api_key'];
-        $joinedTexts = implode("\n", array_values($texts));
-        $params = [
-            'q' => $joinedTexts,
+
+        $body = [
+            'q' => array_values($texts),
             'source' => $sourceLang,
             'target' => $targetLang,
-            'key' => $apiKey,
             'format' => 'text',
         ];
 
-        $response = Http::asForm()->post('https://translation.googleapis.com/language/translate/v2', $params);
+        $response = Http::asJson()->post(
+            'https://translation.googleapis.com/language/translate/v2?key=' . urlencode($apiKey),
+            $body
+        );
+
         if (!$response->successful()) {
             $error = $response->json()['error']['message'] ?? $response->body();
             throw new Exception('Google Translate API error: ' . $error);
         }
 
-        $translatedArray = explode("\n", $response->json()['data']['translations'][0]['translatedText']);
-        if (count($translatedArray) !== count($texts)) {
+        $translations = collect($response->json('data.translations'))
+            ->pluck('translatedText')
+            ->toArray();
+
+        if (count($translations) !== count($texts)) {
             throw new Exception('Mismatch in number of translated texts returned by Google Translate.');
         }
 
-        return array_combine(array_keys($texts), $translatedArray);
+        return array_combine(array_keys($texts), $translations);
     }
 }


### PR DESCRIPTION
The google translate API adds additional line breaks after punctuation marks. This leads to empty values in the response array and triggers the mismatch number exception.

This solution refactors to a correct JSON request which takes every translation as a separate value.