### PR TITLE
API key must be set as query param in JSON post

### DIFF
--- a/src/Drivers/GoogleTranslateDriver.php
+++ b/src/Drivers/GoogleTranslateDriver.php
@@ -24,11 +24,10 @@ class GoogleTranslateDriver implements TranslationDriver
             'source' => $sourceLang,
             'target' => $targetLang,
             'format' => 'text',
-            'key' => $apiKey,
         ];
 
         $response = Http::asJson()->post(
-            'https://translation.googleapis.com/language/translate/v2',
+            'https://translation.googleapis.com/language/translate/v2?key=' . urlencode($apiKey),
             $body
         );
 


### PR DESCRIPTION
The API key must be set as query param when using JSON for the request.
It wont work when passed in within the body.